### PR TITLE
allow disabling smart encoding in count_parts

### DIFF
--- a/lib/sms_part_counter.ex
+++ b/lib/sms_part_counter.ex
@@ -91,7 +91,7 @@ defmodule SmsPartCounter do
       {:ok, "unicode"}
 
   """
-  @spec detect_encoding(binary) :: {:ok | :error, String.t()}
+  @spec detect_encoding(binary, map() | nil) :: {:ok | :error, String.t()}
   def detect_encoding(sms, opts \\ %{}) when is_binary(sms) do
     sms_char_set = MapSet.new(String.codepoints(sms))
     smart_encoding_enabled = Map.get(opts, :smart_encoding, true)

--- a/lib/sms_part_counter.ex
+++ b/lib/sms_part_counter.ex
@@ -140,8 +140,9 @@ defmodule SmsPartCounter do
 
   """
   @spec count_parts(binary) :: %{String.t() => String.t(), String.t() => integer()}
-  def count_parts(sms) when is_binary(sms) do
-    {:ok, encoding} = detect_encoding(sms)
+  def count_parts(sms, opts \\ %{}) when is_binary(sms) do
+    smart_encoding_enabled = Map.get(opts, :smart_encoding, true)
+    {:ok, encoding} = detect_encoding(sms, smart_encoding_enabled: smart_encoding_enabled)
 
     case encoding do
       "gsm_7bit" ->

--- a/lib/sms_part_counter.ex
+++ b/lib/sms_part_counter.ex
@@ -91,7 +91,7 @@ defmodule SmsPartCounter do
       {:ok, "unicode"}
 
   """
-  @spec detect_encoding(binary) :: {:ok | :error, Sting.t()}
+  @spec detect_encoding(binary) :: {:ok | :error, String.t()}
   def detect_encoding(sms, opts \\ %{}) when is_binary(sms) do
     sms_char_set = MapSet.new(String.codepoints(sms))
     smart_encoding_enabled = Map.get(opts, :smart_encoding, true)
@@ -139,10 +139,10 @@ defmodule SmsPartCounter do
       }
 
   """
-  @spec count_parts(binary) :: %{String.t() => String.t(), String.t() => integer()}
+  @spec count_parts(binary, map() | nil) :: %{String.t() => String.t(), String.t() => integer()}
   def count_parts(sms, opts \\ %{}) when is_binary(sms) do
     smart_encoding_enabled = Map.get(opts, :smart_encoding, true)
-    {:ok, encoding} = detect_encoding(sms, smart_encoding_enabled: smart_encoding_enabled)
+    {:ok, encoding} = detect_encoding(sms, smart_encoding: smart_encoding_enabled)
 
     case encoding do
       "gsm_7bit" ->

--- a/lib/sms_part_counter.ex
+++ b/lib/sms_part_counter.ex
@@ -91,10 +91,10 @@ defmodule SmsPartCounter do
       {:ok, "unicode"}
 
   """
-  @spec detect_encoding(binary, map() | nil) :: {:ok | :error, String.t()}
-  def detect_encoding(sms, opts \\ %{}) when is_binary(sms) do
+  @spec detect_encoding(binary, keyword() | nil) :: {:ok | :error, String.t()}
+  def detect_encoding(sms, opts \\ []) when is_binary(sms) do
     sms_char_set = MapSet.new(String.codepoints(sms))
-    smart_encoding_enabled = Map.get(opts, :smart_encoding, true)
+    smart_encoding_enabled = Keyword.get(opts, :smart_encoding, true)
 
     comparison_charset = if smart_encoding_enabled, do: @gsm_7bit_char_set_with_smart_encoding, else: @gsm_7bit_char_set
 
@@ -139,9 +139,9 @@ defmodule SmsPartCounter do
       }
 
   """
-  @spec count_parts(binary, map() | nil) :: %{String.t() => String.t(), String.t() => integer()}
-  def count_parts(sms, opts \\ %{}) when is_binary(sms) do
-    smart_encoding_enabled = Map.get(opts, :smart_encoding, true)
+  @spec count_parts(binary, keyword() | nil) :: %{String.t() => String.t(), String.t() => integer()}
+  def count_parts(sms, opts \\ []) when is_binary(sms) do
+    smart_encoding_enabled = Keyword.get(opts, :smart_encoding, true)
     {:ok, encoding} = detect_encoding(sms, smart_encoding: smart_encoding_enabled)
 
     case encoding do


### PR DESCRIPTION
By default this repo uses Twilio's Smart Encoding feature that replaces unicode characters with their closest utf-8 equivalent. For Bandwidth, this is not possible, so we need a way to disable it when calling the `count_parts/1` function. It was already possible to disable it when calling `detect_encoding/2` but this wasn't used by `count_parts`. This PR adds the same logic to the `count_parts` function to allow passing it through to `detect_encoding`.

Driveby fix spec on detect_encoding.